### PR TITLE
Todo directory cli opt and per-location instances

### DIFF
--- a/executable/go-for-it.vala
+++ b/executable/go-for-it.vala
@@ -1,3 +1,7 @@
+private static string? todo_txt_location = null;
+private static bool print_version = false;
+private static bool show_about_dialog = false;
+
 /**
  * The entry point for running the application.
  */
@@ -9,7 +13,30 @@ public static int main (string[] args) {
     Intl.bindtextdomain(GOFI.GETTEXT_PACKAGE, locale_dir);
 
     apply_desktop_specific_tweaks ();
-    Main app = new Main ();
+
+    var context = new OptionContext (GOFI.APP_NAME);
+    context.add_main_entries (entries, GOFI.EXEC_NAME);
+    context.add_group (Gtk.get_option_group (true));
+
+    try {
+        context.parse (ref args);
+    } catch (Error e) {
+        stdout.printf ("%s: Error: %s \n", GOFI.APP_NAME, e.message);
+        return 0;
+    }
+
+    if (print_version) {
+        stdout.printf ("%s %s\n", GOFI.APP_NAME, GOFI.APP_VERSION);
+        stdout.printf ("Copyright 2014-2017 'Go For it!' Developers.\n");
+        return 0;
+    }
+
+    Main app = new Main (GOFI.APP_ID, todo_txt_location, ApplicationFlags.HANDLES_COMMAND_LINE);
+    if (show_about_dialog) {
+        app.show_about ();
+        return 0;
+    }
+
     int status = app.run (args);
     return status;
 }
@@ -26,3 +53,11 @@ public static void apply_desktop_specific_tweaks () {
         Environment.set_variable ("LIBOVERLAY_SCROLLBAR", "0", true);
     }
 }
+
+const OptionEntry[] entries = {
+    { "todotxt-dir", 'd', 0, OptionArg.FILENAME, out todo_txt_location, N_("Use different Todo.txt directory"), N_("path") },
+    { "version", 'v', 0, OptionArg.NONE, out print_version, N_("Print version info and exit"), null },
+    { "about", 'a', 0, OptionArg.NONE, out show_about_dialog, N_("Show about dialog"), null },
+    { null }
+};
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ vala_precompile (VALA_C ${LIBNAME}
 PACKAGES
     gtk+-3.0
     libnotify
+    posix
 OPTIONS
     ${VALAC_OPTIONS}
 GENERATE_VAPI

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -25,6 +25,7 @@ class Main : Gtk.Application {
     private TaskTimer task_timer;
     private MainWindow win;
 
+    private static string? todo_txt_location = null;
     private static bool print_version = false;
     private static bool show_about_dialog = false;
     /**
@@ -43,7 +44,7 @@ class Main : Gtk.Application {
         }
 
         settings = new SettingsManager.load_from_key_file ();
-        task_manager = new TaskManager(settings);
+        task_manager = new TaskManager(settings, todo_txt_location);
         task_timer = new TaskTimer (settings);
         task_timer.active_task_done.connect ( (task) => {
              task_manager.mark_task_done (task);
@@ -92,6 +93,7 @@ class Main : Gtk.Application {
     }
 
     const OptionEntry[] entries = {
+        { "todotxt-dir", 'd', 0, OptionArg.FILENAME, out todo_txt_location, N_("Use different Todo.txt directory"), N_("path") },
         { "version", 'v', 0, OptionArg.NONE, out print_version, N_("Print version info and exit"), null },
         { "about", 'a', 0, OptionArg.NONE, out show_about_dialog, N_("Show about dialog"), null },
         { null }

--- a/src/TaskManager.vala
+++ b/src/TaskManager.vala
@@ -71,11 +71,7 @@ class TaskManager {
 
         refresh_queued = false;
 
-        if (this.todo_txt_location != null) {
-            load_task_stores (this.todo_txt_location);
-        } else {
-            load_task_stores (settings.todo_txt_location);
-        }
+        load_task_stores (this.todo_txt_location);
         connect_store_signals ();
 
         // Write default tasks

--- a/src/TaskManager.vala
+++ b/src/TaskManager.vala
@@ -25,6 +25,7 @@ class TaskManager {
     private SettingsManager settings;
     // The user's todo.txt related files
     public string? todo_txt_location = null;
+    public string? instance_str = null;
     private File todo_txt_dir;
     private File todo_txt;
     private File done_txt;
@@ -171,6 +172,10 @@ class TaskManager {
     private void load_task_stores (string location) {
         stdout.printf("load_task_stores\n");
         todo_txt_dir = File.new_for_commandline_arg(location);
+        if (this.todo_txt_location != null) {
+            FileInfo finfo = todo_txt_dir.get_parent().query_info(FileAttribute.STANDARD_NAME, 0);
+            this.instance_str = finfo.get_name();
+        }
         todo_txt = todo_txt_dir.get_child ("todo.txt");
         done_txt = todo_txt_dir.get_child ("done.txt");
 

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -25,6 +25,7 @@ class MainWindow : Gtk.ApplicationWindow {
     private SettingsManager settings;
     private bool use_header_bar;
     private bool refreshing = false;
+    private string? instance_str = null;
 
     /* Various GTK Widgets */
     private Gtk.Grid main_layout;
@@ -57,6 +58,12 @@ class MainWindow : Gtk.ApplicationWindow {
         this.task_manager = task_manager;
         this.task_timer = task_timer;
         this.settings = settings;
+
+        if (this.task_manager.instance_str != null) {
+            this.instance_str = this.task_manager.instance_str + " — " + GOFI.APP_NAME;
+        } else {
+            this.instance_str = GOFI.APP_NAME;
+        }
 
         apply_settings ();
 
@@ -107,7 +114,7 @@ class MainWindow : Gtk.ApplicationWindow {
      * Configures the window's properties.
      */
     private void setup_window () {
-        this.title = GOFI.APP_NAME;
+        this.title = this.instance_str;
         this.set_border_width (0);
         restore_win_geometry ();
     }
@@ -210,7 +217,7 @@ class MainWindow : Gtk.ApplicationWindow {
 
         // GTK Header Bar
         header_bar.set_show_close_button (true);
-        header_bar.title = GOFI.APP_NAME;
+        header_bar.title = this.instance_str;
 
         // Add headerbar Buttons here
         header_bar.pack_end (menu_btn);


### PR DESCRIPTION
This branch implements same goal as already mentioned in plans lists selection page. However, while that page, as i can guess, implements management for all lists from single application, there is another approach: have one instance per each location.

It is possible to just create directory, and if DE allowes, simply open it in Go-For-It!
Thus, it is possible to have any number of different lists included to projects (like traditional TODO, ROADMAP, etc), and for nested projects - have separate list for each level as well.

Summaryzing of all features and issues:
- Overriding default desktop list is done by option "--todotxt-dir, -d".
Both variants `--todotxt-dir=dir` and `--todotxt-dir dir` are equivalent.
- Window title always shows location name, and has format `location — Go-For-It!`. When HeaderBar option is enabled, this look is still prefered, because when some text goes to subtitle, it doesn't appear in window list, and thus windows in lists are indistinguishable.
- Location is shown even in default case (simply clicking app icon to start) for better consistence — it would show it anyway, if you specify "-d ~/Todo" occasionaly.

Internal issue: instances have appended location path after application-common part. Due to tight restriction to character set, used in application ID string, slash path delimiters are replaced with periods, but previously periods are replaced with underscore '_'. This makes slash and underscore resulting to same instance, e.g `/foo/bar` and `/foo_bar`.

Possible solutions, as i see:
- either use list switch page for lists, getting to same instance
- custom uniqueness implementation, creating pidfiles in todo.txt location.
- make GApplication to manage files, with support for both SDI (as in this branch) or MDI (with lists switcher page). Besides fix, it would be possible to save/restore session in this way.
```
$ cd ~/dist
$ com.github.jmoerman.go-for-it -d ./tasks
load_task_stores
Reading file: /home/username/dist/tasks/todo.txt
Reading file: /home/username/dist/tasks/done.txt
```
This creates instance `com.github.jmoerman.go-for-it.home.username.dist.tasks`, while running without options results to `com.github.jmoerman.go-for-it.home.username.Todo`
![go-for-it-instance-per-location](https://user-images.githubusercontent.com/3896190/43651269-57c1e59c-975b-11e8-87b2-c3556aaa3829.png)