### PR TITLE
Add dates to the written files

### DIFF
--- a/src/TaskManager.vala
+++ b/src/TaskManager.vala
@@ -95,6 +95,7 @@ class TaskManager {
             string? priority = consume_priority (ref _task);
             var todo_task = new TodoTask (_task, false);
             todo_task.priority = priority;
+            todo_task.creation_date = new GLib.DateTime.now_local ();
             todo_store.add_task (todo_task);
             save_todo_tasks ();
         }

--- a/src/TodoTask.vala
+++ b/src/TodoTask.vala
@@ -36,6 +36,11 @@ public class TodoTask : GLib.Object {
         }
         public set {
             if (_done != value) {
+                if (value) {
+                    completion_date = new GLib.DateTime.now_local ();
+                } else {
+                    completion_date = null;
+                }
                 _done = value;
                 done_changed ();
             }


### PR DESCRIPTION
The completion date is mandatory as per the format and the creation date is also
useful. These are not shown to the user yet in this todo.txt client, but are
used in many others, so it's useful to include them already in the file even
though we don't yet have an implementation for showing them in the UI.

Your implementation of the parsing is much cleaner. Showing the dates (and sorting by them) would be good, but for the time being I'd be somewhat happy even with just saving them as I also use the todo file on my phone and there I already sort by creation date. I can't really use Go-For-It at all if it doesn't include creation dates in the file as then it messes up the file for the other client.