### PR TITLE
Fix build with vala 0.56

### DIFF
--- a/src/Services/TaskTimer.vala
+++ b/src/Services/TaskTimer.vala
@@ -32,7 +32,7 @@ public class GOFI.TaskTimer {
 
     private const int64 US_C = 1000000; // μs<->s conversion
 
-    public const int64 UPDATE_INTERVAL = 60 * US_C;
+    private const int64 UPDATE_INTERVAL = 60 * US_C;
 
     /**
      * A proxy attribute, that does not store any data itself, but provides


### PR DESCRIPTION
```
~/Go-For-It-1.9.6/src/Services/TaskTimer.vala:35.42-35.50: error: value is less accessible than constant `GOFI.TaskTimer.UPDATE_INTERVAL'
   35 |     public const int64 UPDATE_INTERVAL = 60 * US_C;
      |                                          ^~~~~~~~~
```

Closes #172